### PR TITLE
Add Liked Songs to playlists API response

### DIFF
--- a/app/api/spotify/playlists/route.ts
+++ b/app/api/spotify/playlists/route.ts
@@ -53,6 +53,22 @@ export async function GET() {
     image: Array.isArray(p.images) && p.images.length > 0 ? { url: p.images[0].url as string, width: p.images[0].width as number | undefined, height: p.images[0].height as number | undefined } : null,
   }))
 
+  let likedTotal: number | undefined
+  try {
+    const likedRes = await fetch('https://api.spotify.com/v1/me/tracks?limit=1', { headers: { Authorization: `Bearer ${accessToken}` }, cache: 'no-store' })
+    if (likedRes.ok) {
+      const likedData = await likedRes.json()
+      likedTotal = typeof likedData.total === 'number' ? likedData.total : undefined
+    }
+  } catch {}
+
+  playlists.unshift({
+    id: 'liked_songs',
+    name: 'Liked Songs',
+    tracks_total: likedTotal,
+    image: null,
+  })
+
   const res = NextResponse.json({ items: playlists })
   if (updated) {
     const maxAge = Math.max(0, Math.floor((newExpiresAt - Date.now()) / 1000))


### PR DESCRIPTION
## Purpose
The user reported that their Liked Songs auto playlist was missing from the list of playlists. This change ensures that the Liked Songs playlist is always included in the playlists API response, making it visible and accessible to users.

## Code changes
- Added API call to fetch the total count of liked tracks from Spotify's `/me/tracks` endpoint
- Created a synthetic "Liked Songs" playlist object with ID `liked_songs` and the fetched track count
- Inserted the Liked Songs playlist at the beginning of the playlists array using `unshift()`
- Added error handling to gracefully handle cases where the liked tracks count cannot be retrievedTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5dbfe8ff82ad4faeb5203a01790c8eaf/stellar-hub)

👀 [Preview Link](https://5dbfe8ff82ad4faeb5203a01790c8eaf-stellar-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5dbfe8ff82ad4faeb5203a01790c8eaf</projectId>-->
<!--<branchName>stellar-hub</branchName>-->