### PR TITLE
Add Next button to wizard after content selection

### DIFF
--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -73,7 +73,7 @@ export default function ActionPage() {
     { label: 'Review details' },
     { label: 'Start transfer' },
   ]
-  const current = 0
+  const [current, setCurrent] = useState(0)
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">

--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -171,6 +171,18 @@ export default function ActionPage() {
             }}>{spotifyUser ? `Signed in as ${spotifyUser.display_name || spotifyUser.id}` : 'Sign in'}</Button>
             <Button size="lg" variant="outline" className="w-full" disabled={!spotifyUser} onClick={() => setLibraryOpen(true)}>Select content</Button>
           </div>
+          <div className="mt-2 mx-auto max-w-xl px-2">
+            <div className="flex justify-end">
+              <Button
+                variant="link"
+                className="inline-flex items-center gap-1 text-[#7c3aed] hover:text-[#7c3aed]"
+                onClick={() => setCurrent((c) => Math.min(steps.length - 1, c + 1))}
+                disabled={selectedPlaylists.size === 0}
+              >
+                Next <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -3,7 +3,7 @@
 import * as ToggleGroup from '@radix-ui/react-toggle-group'
 import * as Dialog from '@radix-ui/react-dialog'
 import { Button } from '@/components/ui/button'
-import { Check } from 'lucide-react'
+import { Check, ChevronRight } from 'lucide-react'
 import { useState, useEffect } from 'react'
 
 export const dynamic = 'force-static'

--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -176,7 +176,7 @@ export default function ActionPage() {
               <Button
                 variant="link"
                 className="inline-flex items-center gap-1 text-[#7c3aed] hover:text-[#7c3aed]"
-                onClick={() => setCurrent((c) => Math.min(steps.length - 1, c + 1))}
+                onClick={() => { setLibraryOpen(false); setCurrent((c) => Math.min(steps.length - 1, c + 1)) }}
                 disabled={selectedPlaylists.size === 0}
               >
                 Next <ChevronRight className="h-4 w-4" />


### PR DESCRIPTION
## Purpose
Implement proper wizard navigation by adding a "Next" button after the content selection step. The user requested a typical wizard structure with a purple "Next" button with chevron icon positioned on the right side to advance to the next step in the flow (select destination).

## Code changes
- Added `ChevronRight` icon import from lucide-react
- Converted `current` step from static constant to state variable using `useState`
- Added new button container with right-aligned "Next" button
- Button includes purple text styling (`text-[#7c3aed]`), chevron right icon, and click handler to advance wizard step
- Button is disabled when no playlists are selected (`selectedPlaylists.size === 0`)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/800620b59ba0422a9f685e6a9959a8b8/cosmos-hub)

👀 [Preview Link](https://800620b59ba0422a9f685e6a9959a8b8-cosmos-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>800620b59ba0422a9f685e6a9959a8b8</projectId>-->
<!--<branchName>cosmos-hub</branchName>-->