### PR TITLE
Add back button to action page navigation

### DIFF
--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -15,6 +15,7 @@ export default function ActionPage() {
   const [mode, setMode] = useState<'transfer' | 'sync'>('transfer')
   type ServiceId = 'spotify' | 'apple' | 'youtube' | 'tidal' | 'deezer' | 'amazon'
   const [source, setSource] = useState<ServiceId | null>(null)
+  const [destination, setDestination] = useState<ServiceId | null>(null)
   const [spotifyUser, setSpotifyUser] = useState<{ id: string; display_name?: string } | null>(null)
 
   const [libraryOpen, setLibraryOpen] = useState(false)
@@ -137,45 +138,89 @@ export default function ActionPage() {
         <div className="mx-auto mt-8 max-w-xl text-center">
           <p className="mt-2 text-sm text-muted-foreground">Only Spotify is available in this MVP. Others are coming soon.</p>
 
-          <div className="mt-8 grid grid-cols-2 gap-4">
-            {services.map((svc) => {
-              const isSelected = source === svc.id
-              return (
-                <button
-                  key={svc.id}
-                  type="button"
-                  onClick={() => {
-                    if (!svc.enabled) return
-                    setSource((prev) => (prev === svc.id ? null : svc.id))
-                  }}
-                  disabled={!svc.enabled}
-                  className={[
-                    'group flex items-center justify-center rounded-lg border p-4 text-center transition-colors',
-                    'bg-white/70 backdrop-blur-sm dark:bg-slate-900/40 dark:border-slate-800',
-                    svc.enabled ? 'hover:border-[#7c3aed] focus-visible:border-[#7c3aed] focus-visible:ring-[#7c3aed]/40 focus-visible:ring-[3px] outline-none' : 'opacity-50 grayscale cursor-not-allowed',
-                    isSelected ? 'ring-2 ring-[#7c3aed]/60 border-[#7c3aed]' : '',
-                  ].join(' ')}
-                  aria-pressed={isSelected}
-                >
-                  <span className={`service-icon service-icon--${svc.id}`} aria-hidden="true" />
-                  <span className="sr-only">{svc.name}</span>
-                </button>
-              )
-            })}
-          </div>
+          {current === 0 && (
+            <>
+              <div className="mt-8 grid grid-cols-2 gap-4">
+                {services.map((svc) => {
+                  const isSelected = source === svc.id
+                  return (
+                    <button
+                      key={svc.id}
+                      type="button"
+                      onClick={() => {
+                        if (!svc.enabled) return
+                        setSource((prev) => (prev === svc.id ? null : svc.id))
+                      }}
+                      disabled={!svc.enabled}
+                      className={[
+                        'group flex items-center justify-center rounded-lg border p-4 text-center transition-colors',
+                        'bg-white/70 backdrop-blur-sm dark:bg-slate-900/40 dark:border-slate-800',
+                        svc.enabled ? 'hover:border-[#7c3aed] focus-visible:border-[#7c3aed] focus-visible:ring-[#7c3aed]/40 focus-visible:ring-[3px] outline-none' : 'opacity-50 grayscale cursor-not-allowed',
+                        isSelected ? 'ring-2 ring-[#7c3aed]/60 border-[#7c3aed]' : '',
+                      ].join(' ')}
+                      aria-pressed={isSelected}
+                    >
+                      <span className={`service-icon service-icon--${svc.id}`} aria-hidden="true" />
+                      <span className="sr-only">{svc.name}</span>
+                    </button>
+                  )
+                })}
+              </div>
 
-          <div className="mt-8 mx-auto flex max-w-xs flex-col gap-3">
-            <Button size="lg" className="w-full" disabled={!source} onClick={() => {
-              if (source === 'spotify') {
-                window.location.href = '/api/spotify/auth'
-              }
-            }}>{spotifyUser ? `Signed in as ${spotifyUser.display_name || spotifyUser.id}` : 'Sign in'}</Button>
-            <Button size="lg" variant="outline" className="w-full" disabled={!spotifyUser} onClick={() => setLibraryOpen(true)}>{confirmedSelectedCount > 0 ? (
-              <span className="inline-flex items-center gap-2">
-                <Check className="h-4 w-4" /> Selected {confirmedSelectedCount} {confirmedSelectedCount === 1 ? 'playlist' : 'playlists'}
-              </span>
-            ) : 'Select content'}</Button>
-          </div>
+              <div className="mt-8 mx-auto flex max-w-xs flex-col gap-3">
+                <Button size="lg" className="w-full" disabled={!source} onClick={() => {
+                  if (source === 'spotify') {
+                    window.location.href = '/api/spotify/auth'
+                  }
+                }}>{spotifyUser ? `Signed in as ${spotifyUser.display_name || spotifyUser.id}` : 'Sign in'}</Button>
+                <Button size="lg" variant="outline" className="w-full" disabled={!spotifyUser} onClick={() => setLibraryOpen(true)}>{confirmedSelectedCount > 0 ? (
+                  <span className="inline-flex items-center gap-2">
+                    <Check className="h-4 w-4" /> Selected {confirmedSelectedCount} {confirmedSelectedCount === 1 ? 'playlist' : 'playlists'}
+                  </span>
+                ) : 'Select content'}</Button>
+              </div>
+            </>
+          )}
+
+          {current === 1 && (
+            <>
+              <div className="mt-8 grid grid-cols-2 gap-4">
+                {services.map((svc) => {
+                  const isSelected = destination === svc.id
+                  return (
+                    <button
+                      key={svc.id}
+                      type="button"
+                      onClick={() => {
+                        if (!svc.enabled) return
+                        setDestination((prev) => (prev === svc.id ? null : svc.id))
+                      }}
+                      disabled={!svc.enabled}
+                      className={[
+                        'group flex items-center justify-center rounded-lg border p-4 text-center transition-colors',
+                        'bg-white/70 backdrop-blur-sm dark:bg-slate-900/40 dark:border-slate-800',
+                        svc.enabled ? 'hover:border-[#7c3aed] focus-visible:border-[#7c3aed] focus-visible:ring-[#7c3aed]/40 focus-visible:ring-[3px] outline-none' : 'opacity-50 grayscale cursor-not-allowed',
+                        isSelected ? 'ring-2 ring-[#7c3aed]/60 border-[#7c3aed]' : '',
+                      ].join(' ')}
+                      aria-pressed={isSelected}
+                    >
+                      <span className={`service-icon service-icon--${svc.id}`} aria-hidden="true" />
+                      <span className="sr-only">{svc.name}</span>
+                    </button>
+                  )
+                })}
+              </div>
+
+              <div className="mt-8 mx-auto flex max-w-xs flex-col gap-3">
+                <Button size="lg" className="w-full" disabled={!destination} onClick={() => {
+                  if (destination === 'spotify') {
+                    window.location.href = '/api/spotify/auth'
+                  }
+                }}>{spotifyUser ? `Signed in as ${spotifyUser.display_name || spotifyUser.id}` : 'Sign in'}</Button>
+              </div>
+            </>
+          )}
+
           <div className="mt-2 mx-auto max-w-xl px-2">
             <div className="flex items-center justify-between gap-2">
               <Button
@@ -190,7 +235,7 @@ export default function ActionPage() {
                 variant="link"
                 className="inline-flex items-center gap-1 text-[#7c3aed] hover:text-[#7c3aed]"
                 onClick={() => { setLibraryOpen(false); setCurrent((c) => Math.min(steps.length - 1, c + 1)) }}
-                disabled={selectedPlaylists.size === 0}
+                disabled={current === 0 ? !source : current === 1 ? !destination : false}
               >
                 Next <ChevronRight className="h-4 w-4" />
               </Button>

--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -3,7 +3,7 @@
 import * as ToggleGroup from '@radix-ui/react-toggle-group'
 import * as Dialog from '@radix-ui/react-dialog'
 import { Button } from '@/components/ui/button'
-import { Check, ChevronRight } from 'lucide-react'
+import { Check, ChevronRight, ChevronLeft } from 'lucide-react'
 import { useState, useEffect } from 'react'
 
 export const dynamic = 'force-static'
@@ -177,7 +177,15 @@ export default function ActionPage() {
             ) : 'Select content'}</Button>
           </div>
           <div className="mt-2 mx-auto max-w-xl px-2">
-            <div className="flex justify-end">
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                variant="link"
+                className="inline-flex items-center gap-1 text-[#7c3aed] hover:text-[#7c3aed]"
+                onClick={() => setCurrent((c) => Math.max(0, c - 1))}
+                disabled={current === 0}
+              >
+                <ChevronLeft className="h-4 w-4" /> Back
+              </Button>
               <Button
                 variant="link"
                 className="inline-flex items-center gap-1 text-[#7c3aed] hover:text-[#7c3aed]"

--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -177,7 +177,7 @@ export default function ActionPage() {
             ) : 'Select content'}</Button>
           </div>
           <div className="mt-2 mx-auto max-w-xl px-2">
-            <div className="flex items-center justify-end gap-2">
+            <div className="flex items-center justify-between gap-2">
               <Button
                 variant="link"
                 className="inline-flex items-center gap-1 text-[#7c3aed] hover:text-[#7c3aed]"


### PR DESCRIPTION
## Purpose
Add a back button to the left side of the action page to improve navigation UX. The user requested a back button that would be positioned on the left side of the page, aligned with the existing next button.

## Code changes
- Import `ChevronLeft` icon from lucide-react
- Update navigation container to use `justify-between` layout with gap spacing
- Add new back button component with:
  - Link variant styling matching the next button
  - Purple color theme (`#7c3aed`)
  - ChevronLeft icon and "Back" text
  - Click handler to decrement current step (with minimum bound of 0)
  - Disabled state when on first step (`current === 0`)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/409f8ad4d41d4e988a416728571df80c/swoosh-landing)

👀 [Preview Link](https://409f8ad4d41d4e988a416728571df80c-swoosh-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>409f8ad4d41d4e988a416728571df80c</projectId>-->
<!--<branchName>swoosh-landing</branchName>-->