### PR TITLE
Separate source and destination Spotify authentication

### DIFF
--- a/app/api/spotify/playlists/route.ts
+++ b/app/api/spotify/playlists/route.ts
@@ -2,16 +2,20 @@ import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { refreshAccessToken } from '@/lib/auth/spotify'
 
-export async function GET() {
+export async function GET(request: Request) {
   const clientId = process.env.SPOTIFY_CLIENT_ID
   if (!clientId) {
     return NextResponse.json({ error: 'Missing SPOTIFY_CLIENT_ID env' }, { status: 500 })
   }
 
+  const url = new URL(request.url)
+  const ctxParam = url.searchParams.get('ctx')
+  const ctx: 'source' | 'destination' = ctxParam === 'destination' ? 'destination' : 'source'
+
   const cookieStore = cookies()
-  let accessToken = cookieStore.get('spotify_access_token')?.value
-  const refreshToken = cookieStore.get('spotify_refresh_token')?.value
-  const expiresAtStr = cookieStore.get('spotify_expires_at')?.value
+  let accessToken = cookieStore.get(`spotify_${ctx}_access_token`)?.value || cookieStore.get('spotify_access_token')?.value
+  const refreshToken = cookieStore.get(`spotify_${ctx}_refresh_token`)?.value || cookieStore.get('spotify_refresh_token')?.value
+  const expiresAtStr = cookieStore.get(`spotify_${ctx}_expires_at`)?.value || cookieStore.get('spotify_expires_at')?.value
   const expiresAt = expiresAtStr ? Number(expiresAtStr) : 0
 
   let updated = false
@@ -35,15 +39,15 @@ export async function GET() {
   }
 
   const items: any[] = []
-  let url: string | null = 'https://api.spotify.com/v1/me/playlists?limit=50'
-  while (url) {
-    const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` }, cache: 'no-store' })
+  let nextUrl: string | null = 'https://api.spotify.com/v1/me/playlists?limit=50'
+  while (nextUrl) {
+    const res = await fetch(nextUrl, { headers: { Authorization: `Bearer ${accessToken}` }, cache: 'no-store' })
     if (!res.ok) {
       return NextResponse.json({ error: 'Failed to fetch playlists' }, { status: 500 })
     }
     const data = await res.json()
     items.push(...(data.items || []))
-    url = data.next
+    nextUrl = data.next
   }
 
   const playlists = items.map((p) => ({
@@ -72,11 +76,11 @@ export async function GET() {
   const res = NextResponse.json({ items: playlists })
   if (updated) {
     const maxAge = Math.max(0, Math.floor((newExpiresAt - Date.now()) / 1000))
-    res.cookies.set('spotify_access_token', accessToken, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
+    res.cookies.set(`spotify_${ctx}_access_token`, accessToken, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
     if (newRefreshToken) {
-      res.cookies.set('spotify_refresh_token', newRefreshToken, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 60 * 60 * 24 * 30 })
+      res.cookies.set(`spotify_${ctx}_refresh_token`, newRefreshToken, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 60 * 60 * 24 * 30 })
     }
-    res.cookies.set('spotify_expires_at', String(newExpiresAt), { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
+    res.cookies.set(`spotify_${ctx}_expires_at`, String(newExpiresAt), { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
   }
   return res
 }


### PR DESCRIPTION
## Purpose

The user requested that the sign-in button in step 2 (select destination) should be an independent instance, separate from the source account authentication. This allows users to authenticate with different Spotify accounts for source and destination services during playlist transfers.

## Code changes

- **Frontend state management**: Split single `spotifyUser` state into separate `spotifySourceUser` and `spotifyDestUser` states to track authentication for each context independently
- **API context parameter**: Added `ctx` query parameter to all Spotify API endpoints (`/auth`, `/me`, `/playlists`) to distinguish between 'source' and 'destination' contexts
- **Cookie scoping**: Updated cookie names to include context prefix (`spotify_source_*` and `spotify_destination_*`) for access tokens, refresh tokens, and expiration times
- **OAuth flow updates**: Modified authentication flow to embed context in state parameter and handle context-specific cookie management
- **Backward compatibility**: Added fallback to legacy cookie names to maintain compatibility during transition
- **UI updates**: Updated sign-in buttons and user display to use context-specific user statesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0eddc91744f4938b31f03cd4f4d325c/aura-zone)

👀 [Preview Link](https://a0eddc91744f4938b31f03cd4f4d325c-aura-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0eddc91744f4938b31f03cd4f4d325c</projectId>-->
<!--<branchName>aura-zone</branchName>-->