### PR TITLE
Fix auth flow navigation after destination account signin

### DIFF
--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -31,6 +31,31 @@ export default function ActionPage() {
   const [confirmedSelectedCount, setConfirmedSelectedCount] = useState(0)
 
   useEffect(() => {
+    try {
+      const params = new URLSearchParams(window.location.search)
+      const auth = params.get('auth')
+      const ctx = params.get('ctx')
+      const authError = params.get('authError')
+
+      if (auth === 'spotify') {
+        if (ctx === 'destination') {
+          setDestination('spotify')
+          setCurrent(1)
+        } else {
+          setSource('spotify')
+          setCurrent(0)
+        }
+      }
+
+      if (auth || authError || ctx) {
+        const url = new URL(window.location.href)
+        url.searchParams.delete('auth')
+        url.searchParams.delete('ctx')
+        url.searchParams.delete('authError')
+        window.history.replaceState({}, '', url.toString())
+      }
+    } catch {}
+
     fetch('/api/spotify/me?ctx=source', { cache: 'no-store' })
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => { if (data) setSpotifySourceUser(data) })


### PR DESCRIPTION
## Purpose
Fix the authentication flow to properly return users to step 2 after signing in to their destination account. The user reported that the auth process wasn't navigating back to the correct step after completing destination account authentication.

## Code changes
- Added URL parameter parsing in `useEffect` to handle auth flow redirects
- Implemented logic to set destination service and navigate to step 1 when `auth=spotify` and `ctx=destination`
- Added fallback to set source service and navigate to step 0 for other auth contexts
- Included URL cleanup to remove auth-related parameters after processing
- Wrapped parameter handling in try-catch for error safetyTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0eddc91744f4938b31f03cd4f4d325c/quantum-forge)

👀 [Preview Link](https://a0eddc91744f4938b31f03cd4f4d325c-quantum-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0eddc91744f4938b31f03cd4f4d325c</projectId>-->
<!--<branchName>quantum-forge</branchName>-->