### PR TITLE
Fix auth redirect to preserve step state in action flow

### DIFF
--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -30,7 +30,7 @@ export default function ActionPage() {
   const [selectedPlaylists, setSelectedPlaylists] = useState<Set<string>>(new Set())
   const [confirmedSelectedCount, setConfirmedSelectedCount] = useState(0)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     try {
       const params = new URLSearchParams(window.location.search)
       const auth = params.get('auth')
@@ -55,7 +55,9 @@ export default function ActionPage() {
         window.history.replaceState({}, '', url.toString())
       }
     } catch {}
+  }, [])
 
+  useEffect(() => {
     fetch('/api/spotify/me?ctx=source', { cache: 'no-store' })
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => { if (data) setSpotifySourceUser(data) })

--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -4,7 +4,7 @@ import * as ToggleGroup from '@radix-ui/react-toggle-group'
 import * as Dialog from '@radix-ui/react-dialog'
 import { Button } from '@/components/ui/button'
 import { Check, ChevronRight, ChevronLeft } from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useLayoutEffect } from 'react'
 
 export const dynamic = 'force-static'
 


### PR DESCRIPTION
## Purpose

The user wanted to improve the authentication flow UX by ensuring the site remembers its state when authenticating the destination account in step 2. Previously, after authentication, users were redirected back to step 1 before jumping to step 2, which was visually jarring. The goal was to have the auth process return directly to step 2 for a smoother user experience.

## Code changes

- Changed `useEffect` to `useLayoutEffect` for URL parameter processing to ensure it runs synchronously before the browser paint
- Split the effect into two separate hooks: one for URL parameter handling (using `useLayoutEffect`) and another for the Spotify API call (using `useEffect`)
- Added proper dependency array `[]` to the `useLayoutEffect` to prevent unnecessary re-runs
- This ensures the step state is preserved and restored before the component renders, preventing the visual jump from step 1 to step 2To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0eddc91744f4938b31f03cd4f4d325c/neon-den)

👀 [Preview Link](https://a0eddc91744f4938b31f03cd4f4d325c-neon-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0eddc91744f4938b31f03cd4f4d325c</projectId>-->
<!--<branchName>neon-den</branchName>-->