### PR TITLE
Make sign in button responsive to service selection

### DIFF
--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -207,7 +207,7 @@ export default function ActionPage() {
                   if (source === 'spotify') {
                     window.location.href = '/api/spotify/auth?ctx=source'
                   }
-                }}>{spotifySourceUser ? `Signed in as ${spotifySourceUser.display_name || spotifySourceUser.id}` : 'Sign in'}</Button>
+                }}>{source === 'spotify' && spotifySourceUser ? `Signed in as ${spotifySourceUser.display_name || spotifySourceUser.id}` : 'Sign in'}</Button>
                 <Button size="lg" variant="outline" className="w-full" disabled={!spotifySourceUser} onClick={() => setLibraryOpen(true)}>{confirmedSelectedCount > 0 ? (
                   <span className="inline-flex items-center gap-2">
                     <Check className="h-4 w-4" /> Selected {confirmedSelectedCount} {confirmedSelectedCount === 1 ? 'playlist' : 'playlists'}
@@ -251,7 +251,7 @@ export default function ActionPage() {
                   if (destination === 'spotify') {
                     window.location.href = '/api/spotify/auth?ctx=destination'
                   }
-                }}>{spotifyDestUser ? `Signed in as ${spotifyDestUser.display_name || spotifyDestUser.id}` : 'Sign in'}</Button>
+                }}>{destination === 'spotify' && spotifyDestUser ? `Signed in as ${spotifyDestUser.display_name || spotifyDestUser.id}` : 'Sign in'}</Button>
               </div>
             </>
           )}


### PR DESCRIPTION
## Purpose

The user requested that the sign in button be responsive to service selection. The button should only display "sign in as X" when the relevant service (Spotify) is actually selected, improving the user experience by showing contextually appropriate information.

## Code changes

Updated the sign in button logic in both source and destination sections to check if the service is selected before showing user information:
- Added condition `source === 'spotify' &&` before displaying Spotify source user info
- Added condition `destination === 'spotify' &&` before displaying Spotify destination user info
- Now the button only shows "Signed in as [username]" when Spotify is the selected service and user is authenticatedTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 18`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0eddc91744f4938b31f03cd4f4d325c/curry-forge)

👀 [Preview Link](https://a0eddc91744f4938b31f03cd4f4d325c-curry-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0eddc91744f4938b31f03cd4f4d325c</projectId>-->
<!--<branchName>curry-forge</branchName>-->