### PR TITLE
Add custom artwork for liked songs auto playlist

### DIFF
--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -300,6 +300,7 @@ export default function ActionPage() {
               <ul className="space-y-1">
                 {playlists.map((pl) => {
                   const checked = selectedPlaylists.has(pl.id)
+                  const artworkUrl = pl.id === 'liked_songs' ? 'https://cdn.builder.io/api/v1/image/assets%2F672bd2452a84448ea16383bbff6a43d6%2F533ea5db8ac54bf58d52fcac265b743a?format=webp&width=800' : (pl.image?.url || null)
                   return (
                     <li key={pl.id}>
                       <button type="button" onClick={() => togglePick(pl.id)} className={[
@@ -309,9 +310,9 @@ export default function ActionPage() {
                       ].join(' ')}>
                         <input type="checkbox" checked={checked} onChange={() => togglePick(pl.id)} className="pointer-events-none" />
                         <div className="flex min-w-0 flex-1 items-center gap-3">
-                          {pl.image ? (
+                          {artworkUrl ? (
                             // eslint-disable-next-line @next/next/no-img-element
-                            <img src={pl.image.url} alt="" className="h-8 w-8 rounded object-cover" />
+                            <img src={artworkUrl} alt="" className="h-8 w-8 rounded object-cover" />
                           ) : (
                             <div className="h-8 w-8 rounded bg-[#7c3aed]/10" />
                           )}


### PR DESCRIPTION
## Purpose
The user requested to use a specific artwork image for the liked songs auto playlist in the /action page to provide a custom visual representation for this special playlist type.

## Code changes
- Added conditional logic to use a custom artwork URL for the 'liked_songs' playlist
- Modified the artwork rendering logic to check for the new `artworkUrl` variable instead of directly using `pl.image`
- The liked songs playlist now displays a specific image from cdn.builder.io while other playlists continue to use their existing artwork or fallback to the default placeholderTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 20`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0eddc91744f4938b31f03cd4f4d325c/spark-zone)

👀 [Preview Link](https://a0eddc91744f4938b31f03cd4f4d325c-spark-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0eddc91744f4938b31f03cd4f4d325c</projectId>-->
<!--<branchName>spark-zone</branchName>-->