### PR TITLE
Add server-side playlist transfer with live progress tracking

### DIFF
--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -15,6 +15,10 @@ type ServiceId = 'spotify' | 'apple' | 'youtube' | 'tidal' | 'deezer' | 'amazon'
 
 type SpotifyUser = { id: string; display_name?: string } | null
 
+type TransferItem = { playlistId: string; playlistName: string; status: 'pending' | 'running' | 'completed' | 'failed'; total: number; added: number; message?: string; error?: string }
+
+type TransferState = { id: string; status: 'queued' | 'running' | 'completed' | 'failed'; createdAt: number; updatedAt: number; logs: string[]; items: TransferItem[] }
+
 export default function ActionPage() {
   const [mode, setMode] = useState<'transfer' | 'sync'>('transfer')
   const [source, setSource] = useState<ServiceId | null>(null)

--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -359,10 +359,38 @@ export default function ActionPage() {
                 </div>
               </div>
               <div className="mt-4 flex justify-center">
-                <Button size="lg" type="button" disabled={!source || !destination || playlists.filter((pl) => selectedPlaylists.has(pl.id)).length === 0 || (source === 'spotify' && !spotifySourceUser) || (destination === 'spotify' && !spotifyDestUser)}>
-                  Start transfer
+                <Button size="lg" type="button" onClick={startTransfer} disabled={starting || !source || !destination || playlists.filter((pl) => selectedPlaylists.has(pl.id)).length === 0 || (source === 'spotify' && !spotifySourceUser) || (destination === 'spotify' && !spotifyDestUser)}>
+                  {starting ? 'Starting...' : 'Start transfer'}
                 </Button>
               </div>
+              {startError && (
+                <div className="mt-3 text-center text-sm text-red-600 dark:text-red-400">{startError}</div>
+              )}
+              {job && (
+                <div className="mt-6 rounded-xl border bg-white/70 p-5 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/40">
+                  <div className="text-base font-semibold">Transfer progress</div>
+                  <div className="mt-1 text-sm text-muted-foreground">Status: {job.status}</div>
+                  <div className="mt-4 space-y-3">
+                    {job.items.map((it) => (
+                      <div key={it.playlistId} className="rounded-lg border bg-white/50 p-3 dark:border-slate-800 dark:bg-slate-900/30">
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium">{it.playlistName}</div>
+                            <div className="text-xs text-muted-foreground">{it.status === 'running' ? `${it.added}/${it.total}` : it.status}</div>
+                          </div>
+                          <div className="w-40 h-2 rounded bg-slate-200 dark:bg-slate-800 overflow-hidden">
+                            <div className="h-full bg-[#7c3aed]" style={{ width: it.total > 0 ? `${Math.round((it.added / it.total) * 100)}%` : '0%' }} />
+                          </div>
+                        </div>
+                        {it.error && <div className="mt-2 text-xs text-red-600 dark:text-red-400">{it.error}</div>}
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-4 rounded-lg border bg-white/50 p-3 text-xs dark:border-slate-800 dark:bg-slate-900/30 max-h-40 overflow-auto">
+                    {job.logs.length === 0 ? <div className="text-muted-foreground">No logs yet</div> : job.logs.map((l, i) => (<div key={i}>{l}</div>))}
+                  </div>
+                </div>
+              )}
             </div>
           )}
 

--- a/app/api/spotify/auth/route.ts
+++ b/app/api/spotify/auth/route.ts
@@ -25,6 +25,9 @@ export async function GET(request: Request) {
     'playlist-read-private',
     'playlist-read-collaborative',
     'user-library-read',
+    'playlist-modify-private',
+    'playlist-modify-public',
+    'ugc-image-upload',
   ].join(' ')
 
   const authorizeUrl = buildAuthorizeUrl({

--- a/app/api/transfer/start/route.ts
+++ b/app/api/transfer/start/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { startTransfer } from '@/lib/transfer/serverJobs'
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => null)
+    if (!body || !Array.isArray(body.playlists)) {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+    }
+    const playlists: { id: string; name: string }[] = body.playlists
+      .filter((p: any) => p && typeof p.id === 'string' && typeof p.name === 'string')
+    if (playlists.length === 0) {
+      return NextResponse.json({ error: 'No playlists provided' }, { status: 400 })
+    }
+    const job = startTransfer({ playlists })
+    return NextResponse.json({ id: job.id, state: job })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'Server error' }, { status: 500 })
+  }
+}

--- a/app/api/transfer/start/route.ts
+++ b/app/api/transfer/start/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
 import { startTransfer } from '@/lib/transfer/serverJobs'
 
 export async function POST(request: Request) {
@@ -12,7 +13,17 @@ export async function POST(request: Request) {
     if (playlists.length === 0) {
       return NextResponse.json({ error: 'No playlists provided' }, { status: 400 })
     }
-    const job = startTransfer({ playlists })
+    const cookieStore = cookies()
+    const auth = {
+      sourceAccessToken: cookieStore.get('spotify_source_access_token')?.value || cookieStore.get('spotify_access_token')?.value || '',
+      sourceRefreshToken: cookieStore.get('spotify_source_refresh_token')?.value || cookieStore.get('spotify_refresh_token')?.value,
+      destAccessToken: cookieStore.get('spotify_destination_access_token')?.value || '',
+      destRefreshToken: cookieStore.get('spotify_destination_refresh_token')?.value,
+    }
+    if (!auth.sourceAccessToken || !auth.destAccessToken) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    }
+    const job = startTransfer({ playlists, auth })
     return NextResponse.json({ id: job.id, state: job })
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || 'Server error' }, { status: 500 })

--- a/app/api/transfer/status/route.ts
+++ b/app/api/transfer/status/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { getJob } from '@/lib/transfer/serverJobs'
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const id = url.searchParams.get('id')
+  if (!id) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+  }
+  const job = getJob(id)
+  if (!job) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  return NextResponse.json(job)
+}

--- a/lib/transfer/serverJobs.ts
+++ b/lib/transfer/serverJobs.ts
@@ -46,14 +46,7 @@ async function getSpotifyAccessToken(ctx: 'source' | 'destination'): Promise<str
     try {
       const refreshed = await refreshAccessToken({ refresh_token: refreshToken, client_id: clientId })
       accessToken = refreshed.access_token
-      const newExpiresAt = Date.now() + refreshed.expires_in * 1000 - 30 * 1000
-      const maxAge = Math.max(0, Math.floor((newExpiresAt - Date.now()) / 1000))
-      // Update cookies with new tokens
-      cookies().set(`spotify_${ctx}_access_token`, accessToken, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
-      if (refreshed.refresh_token) {
-        cookies().set(`spotify_${ctx}_refresh_token`, refreshed.refresh_token, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 60 * 60 * 24 * 30 })
-      }
-      cookies().set(`spotify_${ctx}_expires_at`, String(newExpiresAt), { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
+      // We only need the refreshed access token for this job scope; do not attempt to persist cookies here
     } catch {
       // ignore
     }

--- a/lib/transfer/serverJobs.ts
+++ b/lib/transfer/serverJobs.ts
@@ -1,4 +1,3 @@
-import { cookies } from 'next/headers'
 import { refreshAccessToken } from '@/lib/auth/spotify'
 import crypto from 'crypto'
 

--- a/lib/transfer/serverJobs.ts
+++ b/lib/transfer/serverJobs.ts
@@ -1,0 +1,227 @@
+import { cookies } from 'next/headers'
+import { refreshAccessToken } from '@/lib/auth/spotify'
+
+export type JobStatus = 'queued' | 'running' | 'completed' | 'failed'
+
+export type PlaylistProgress = {
+  playlistId: string
+  playlistName: string
+  status: 'pending' | 'running' | 'completed' | 'failed'
+  total: number
+  added: number
+  message?: string
+  error?: string
+}
+
+export type TransferJobState = {
+  id: string
+  status: JobStatus
+  createdAt: number
+  updatedAt: number
+  logs: string[]
+  items: PlaylistProgress[]
+}
+
+export type StartTransferInput = {
+  playlists: { id: string; name: string }[]
+}
+
+const jobs = new Map<string, TransferJobState>()
+
+function log(job: TransferJobState, line: string) {
+  job.logs.push(line)
+  job.updatedAt = Date.now()
+}
+
+async function getSpotifyAccessToken(ctx: 'source' | 'destination'): Promise<string | null> {
+  const clientId = process.env.SPOTIFY_CLIENT_ID
+  if (!clientId) return null
+  const cookieStore = cookies()
+  let accessToken = cookieStore.get(`spotify_${ctx}_access_token`)?.value || cookieStore.get('spotify_access_token')?.value || null
+  const refreshToken = cookieStore.get(`spotify_${ctx}_refresh_token`)?.value || cookieStore.get('spotify_refresh_token')?.value || null
+  const expiresAtStr = cookieStore.get(`spotify_${ctx}_expires_at`)?.value || cookieStore.get('spotify_expires_at')?.value
+  const expiresAt = expiresAtStr ? Number(expiresAtStr) : 0
+
+  if ((!accessToken || Date.now() >= expiresAt) && refreshToken) {
+    try {
+      const refreshed = await refreshAccessToken({ refresh_token: refreshToken, client_id: clientId })
+      accessToken = refreshed.access_token
+      const newExpiresAt = Date.now() + refreshed.expires_in * 1000 - 30 * 1000
+      const maxAge = Math.max(0, Math.floor((newExpiresAt - Date.now()) / 1000))
+      // Update cookies with new tokens
+      cookies().set(`spotify_${ctx}_access_token`, accessToken, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
+      if (refreshed.refresh_token) {
+        cookies().set(`spotify_${ctx}_refresh_token`, refreshed.refresh_token, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 60 * 60 * 24 * 30 })
+      }
+      cookies().set(`spotify_${ctx}_expires_at`, String(newExpiresAt), { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
+    } catch {
+      // ignore
+    }
+  }
+
+  return accessToken
+}
+
+async function spotifyMe(token: string) {
+  const res = await fetch('https://api.spotify.com/v1/me', { headers: { Authorization: `Bearer ${token}` } })
+  if (!res.ok) throw new Error('Failed to fetch Spotify user')
+  return res.json() as Promise<{ id: string }>
+}
+
+async function fetchPlaylistDetails(token: string, playlistId: string) {
+  if (playlistId === 'liked_songs') {
+    return { id: 'liked_songs', name: 'Liked Songs', description: '' }
+  }
+  const url = `https://api.spotify.com/v1/playlists/${encodeURIComponent(playlistId)}?fields=id,name,description,images(total,height,width,url)`
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` }, cache: 'no-store' })
+  if (!res.ok) throw new Error('Failed to get playlist details')
+  return res.json() as Promise<{ id: string; name: string; description?: string; images?: { url: string; width?: number; height?: number }[] }>
+}
+
+async function fetchPlaylistTrackUris(token: string, playlistId: string): Promise<string[]> {
+  const uris: string[] = []
+  if (playlistId === 'liked_songs') {
+    let nextUrl: string | null = 'https://api.spotify.com/v1/me/tracks?limit=50'
+    while (nextUrl) {
+      const res = await fetch(nextUrl, { headers: { Authorization: `Bearer ${token}` }, cache: 'no-store' })
+      if (!res.ok) throw new Error('Failed to fetch liked songs')
+      const data = await res.json()
+      for (const item of data.items || []) {
+        const track = item.track
+        if (track && track.uri) uris.push(track.uri as string)
+      }
+      nextUrl = data.next
+    }
+    return uris
+  }
+  let nextUrl: string | null = `https://api.spotify.com/v1/playlists/${encodeURIComponent(playlistId)}/tracks?limit=100`
+  while (nextUrl) {
+    const res = await fetch(nextUrl, { headers: { Authorization: `Bearer ${token}` }, cache: 'no-store' })
+    if (!res.ok) throw new Error('Failed to fetch playlist tracks')
+    const data = await res.json()
+    for (const item of data.items || []) {
+      const track = item.track
+      if (track && track.uri) uris.push(track.uri as string)
+    }
+    nextUrl = data.next
+  }
+  return uris
+}
+
+async function createDestinationPlaylist(token: string, name: string, description?: string) {
+  const res = await fetch('https://api.spotify.com/v1/me/playlists', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, description: description || '' }),
+  })
+  if (!res.ok) throw new Error('Failed to create destination playlist')
+  return res.json() as Promise<{ id: string }>
+}
+
+async function setPlaylistCover(token: string, playlistId: string, imageUrl?: string) {
+  if (!imageUrl) return
+  try {
+    const imgRes = await fetch(imageUrl)
+    if (!imgRes.ok) return
+    const contentType = imgRes.headers.get('content-type') || ''
+    if (!contentType.includes('jpeg') && !contentType.includes('jpg')) {
+      return
+    }
+    const arrBuf = await imgRes.arrayBuffer()
+    // Spotify requires base64-encoded JPEG with no headers, body is raw base64
+    const b64 = Buffer.from(arrBuf).toString('base64')
+    await fetch(`https://api.spotify.com/v1/playlists/${encodeURIComponent(playlistId)}/images`, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'image/jpeg' },
+      body: b64,
+    })
+  } catch {
+    // best-effort only
+  }
+}
+
+async function addTracksInBatches(token: string, playlistId: string, uris: string[], onProgress: (added: number) => void) {
+  for (let i = 0; i < uris.length; i += 100) {
+    const batch = uris.slice(i, i + 100)
+    const res = await fetch(`https://api.spotify.com/v1/playlists/${encodeURIComponent(playlistId)}/tracks`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ uris: batch })
+    })
+    if (!res.ok) throw new Error('Failed to add tracks')
+    onProgress(batch.length)
+  }
+}
+
+async function runSpotifyToSpotify(job: TransferJobState, input: StartTransferInput) {
+  const sourceToken = await getSpotifyAccessToken('source')
+  const destToken = await getSpotifyAccessToken('destination')
+  if (!sourceToken || !destToken) {
+    job.status = 'failed'
+    job.items.forEach((it) => { it.status = 'failed'; it.error = 'Not authenticated'; })
+    log(job, 'Authentication missing. Please sign in to both accounts.')
+    return
+  }
+
+  // Warm up destination user call to ensure validity
+  await spotifyMe(destToken)
+
+  for (const item of job.items) {
+    try {
+      item.status = 'running'
+      log(job, `Reading playlist: ${item.playlistName}`)
+      const details = await fetchPlaylistDetails(sourceToken, item.playlistId)
+      const uris = await fetchPlaylistTrackUris(sourceToken, item.playlistId)
+      item.total = uris.length
+      log(job, `Found ${uris.length} tracks`)
+      log(job, `Creating destination playlist: ${details.name}`)
+      const created = await createDestinationPlaylist(destToken, details.name, details.description)
+      // Best-effort cover copy
+      const coverUrl = details && (details as any).images && Array.isArray((details as any).images) && (details as any).images[0]?.url
+      await setPlaylistCover(destToken, created.id, coverUrl)
+      log(job, `Adding tracks...`)
+      await addTracksInBatches(destToken, created.id, uris, (added) => { item.added += added; item.message = `${item.added}/${item.total}` })
+      item.status = 'completed'
+      log(job, `Completed: ${details.name}`)
+    } catch (e: any) {
+      item.status = 'failed'
+      item.error = e?.message || 'Unknown error'
+      log(job, `Failed ${item.playlistName}: ${item.error}`)
+    }
+  }
+
+  job.status = job.items.some((i) => i.status === 'failed') ? 'failed' : 'completed'
+}
+
+export function startTransfer(input: StartTransferInput) {
+  const id = `job_${crypto.randomUUID()}`
+  const now = Date.now()
+  const job: TransferJobState = {
+    id,
+    status: 'queued',
+    createdAt: now,
+    updatedAt: now,
+    logs: [],
+    items: input.playlists.map((p) => ({ playlistId: p.id, playlistName: p.name, status: 'pending', total: 0, added: 0 })),
+  }
+  jobs.set(id, job)
+
+  // Run async without awaiting response
+  ;(async () => {
+    try {
+      job.status = 'running'
+      await runSpotifyToSpotify(job, input)
+    } catch (e: any) {
+      job.status = 'failed'
+      log(job, e?.message || 'Unknown error')
+    } finally {
+      job.updatedAt = Date.now()
+    }
+  })()
+
+  return job
+}
+
+export function getJob(id: string) {
+  return jobs.get(id) || null
+}

--- a/lib/transfer/serverJobs.ts
+++ b/lib/transfer/serverJobs.ts
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers'
 import { refreshAccessToken } from '@/lib/auth/spotify'
+import crypto from 'crypto'
 
 export type JobStatus = 'queued' | 'running' | 'completed' | 'failed'
 


### PR DESCRIPTION
## Purpose

Implement server-side playlist transfer functionality that creates 1:1 copies of playlists from source to destination service without requiring the user to stay online. The transfer includes artwork, description, and songs in their original order, with a live progress card providing real-time feedback during the operation.

## Code changes

- **Frontend (ActionPage)**: Added transfer job state management with polling for live updates, progress UI showing individual playlist status and overall transfer progress
- **API endpoints**: Created `/api/transfer/start` to initiate transfers and `/api/transfer/status` for polling job status
- **Transfer engine**: Implemented `serverJobs.ts` with complete Spotify-to-Spotify transfer logic including playlist creation, track copying, and cover art transfer
- **Authentication**: Extended Spotify OAuth scopes to include playlist modification and image upload permissions
- **Progress tracking**: Added real-time progress bars, status indicators, and error handling for individual playlists and overall transfer stateTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 23`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0eddc91744f4938b31f03cd4f4d325c/zenith-haven)

👀 [Preview Link](https://a0eddc91744f4938b31f03cd4f4d325c-zenith-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0eddc91744f4938b31f03cd4f4d325c</projectId>-->
<!--<branchName>zenith-haven</branchName>-->