### PR TITLE
Persist transfer state across page refreshes

### DIFF
--- a/app/api/transfer/start/route.ts
+++ b/app/api/transfer/start/route.ts
@@ -24,7 +24,9 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
     }
     const job = startTransfer({ playlists, auth })
-    return NextResponse.json({ id: job.id, state: job })
+    const res = NextResponse.json({ id: job.id, state: job })
+    res.cookies.set('active_transfer_job_id', job.id, { path: '/', httpOnly: false, maxAge: 60 * 60 })
+    return res
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || 'Server error' }, { status: 500 })
   }


### PR DESCRIPTION
## Purpose

The user reported that refreshing the page during an active transfer would cause the application to lose track of the transfer state, making it appear as if the transfer state wasn't server-sided. This PR addresses that issue by implementing client-side persistence to maintain transfer state across page refreshes.

## Code changes

- **Client-side persistence**: Added localStorage and cookie storage for active transfer job IDs to maintain state across page refreshes
- **State restoration**: Added useEffect hook to check for existing transfer job ID on page load and restore the transfer state
- **Automatic cleanup**: Implemented cleanup of persisted data when transfers complete, fail, or are not found
- **Server-side cookie setting**: Modified the transfer start endpoint to set a cookie with the job ID for additional persistence
- **UI state management**: Automatically navigate to the transfer progress view when restoring an active transferTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 24`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0eddc91744f4938b31f03cd4f4d325c/vortex-zone)

👀 [Preview Link](https://a0eddc91744f4938b31f03cd4f4d325c-vortex-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0eddc91744f4938b31f03cd4f4d325c</projectId>-->
<!--<branchName>vortex-zone</branchName>-->