### PR TITLE
Add destination playlist selector for sync mode

### DIFF
--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -109,6 +109,23 @@ export default function ActionPage() {
       .finally(() => setLoadingPlaylists(false))
   }, [libraryOpen, source, spotifySourceUser])
 
+  useEffect(() => {
+    if (!destLibraryOpen) return
+    if (destination !== 'spotify' || !spotifyDestUser) return
+    setLoadingDestPlaylists(true)
+    setDestPlaylistError(null)
+    fetch('/api/spotify/playlists?ctx=destination', { cache: 'no-store' })
+      .then(async (r) => {
+        if (!r.ok) throw new Error('Failed to load playlists')
+        return r.json()
+      })
+      .then((data) => {
+        setDestPlaylists((data?.items || []) as SpotifyPlaylist[])
+      })
+      .catch(() => setDestPlaylistError('Unable to load playlists'))
+      .finally(() => setLoadingDestPlaylists(false))
+  }, [destLibraryOpen, destination, spotifyDestUser])
+
   const togglePick = (id: string) => {
     setSelectedPlaylists((prev) => {
       const next = new Set(prev)

--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -34,6 +34,14 @@ export default function ActionPage() {
   const [selectedPlaylists, setSelectedPlaylists] = useState<Set<string>>(new Set())
   const [confirmedSelectedCount, setConfirmedSelectedCount] = useState(0)
 
+  // Destination playlist picker (sync mode)
+  const [destLibraryOpen, setDestLibraryOpen] = useState(false)
+  const [destPlaylists, setDestPlaylists] = useState<SpotifyPlaylist[]>([])
+  const [loadingDestPlaylists, setLoadingDestPlaylists] = useState(false)
+  const [destPlaylistError, setDestPlaylistError] = useState<string | null>(null)
+  const [selectedDestPlaylist, setSelectedDestPlaylist] = useState<string | null>(null)
+  const [confirmedDestSelected, setConfirmedDestSelected] = useState(false)
+
   useEffect(() => {
     if (mode === 'sync') {
       setSelectedPlaylists((prev) => {

--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -578,6 +578,61 @@ export default function ActionPage() {
           </Dialog.Content>
         </Dialog.Portal>
       </Dialog.Root>
+
+      <Dialog.Root open={destLibraryOpen} onOpenChange={(o) => setDestLibraryOpen(o)}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[95vw] max-w-2xl max-h-[80vh] -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-white/70 p-0 text-left shadow-xl backdrop-blur-sm focus:outline-none dark:bg-slate-900/60 dark:border-slate-800 flex flex-col">
+            <div className="p-5 border-b dark:border-slate-800">
+              <Dialog.Title className="text-lg font-semibold">Destination playlists</Dialog.Title>
+              <Dialog.Description className="text-sm text-muted-foreground">Choose the playlist to sync into</Dialog.Description>
+            </div>
+            <div className="flex-1 overflow-auto p-3">
+              {loadingDestPlaylists && (
+                <div className="p-6 text-center text-sm text-muted-foreground">Loading playlists...</div>
+              )}
+              {!loadingDestPlaylists && destPlaylistError && (
+                <div className="p-6 text-center text-sm text-red-600 dark:text-red-400">{destPlaylistError}</div>
+              )}
+              {!loadingDestPlaylists && !destPlaylistError && destPlaylists.filter((pl) => pl.id !== 'liked_songs').length === 0 && (
+                <div className="p-6 text-center text-sm text-muted-foreground">No playlists found</div>
+              )}
+              <ul className="space-y-1">
+                {destPlaylists.filter((pl) => pl.id !== 'liked_songs').map((pl) => {
+                  const checked = selectedDestPlaylist === pl.id
+                  const artworkUrl = pl.image?.url || null
+                  return (
+                    <li key={pl.id}>
+                      <button type="button" onClick={() => togglePickDest(pl.id)} className={[
+                        'flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left transition-colors',
+                        'bg-white/50 hover:border-[#7c3aed] dark:bg-slate-900/30 dark:border-slate-800',
+                        checked ? 'ring-1 ring-[#7c3aed] border-[#7c3aed]' : '',
+                      ].join(' ')}>
+                        <input type="radio" name="playlist-pick-destination" checked={checked} onChange={() => togglePickDest(pl.id)} className="pointer-events-none" />
+                        <div className="flex min-w-0 flex-1 items-center gap-3">
+                          {artworkUrl ? (
+                            <img src={artworkUrl} alt="" className="h-8 w-8 rounded object-cover" />
+                          ) : (
+                            <div className="h-8 w-8 rounded bg-[#7c3aed]/10" />
+                          )}
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-sm font-medium">{pl.name}</div>
+                            <div className="text-xs text-muted-foreground">{typeof pl.tracks_total === 'number' ? `${pl.tracks_total} tracks` : 'Playlist'}</div>
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+            <div className="shrink-0 flex items-center justify-between gap-3 border-t bg-white/70 px-4 py-3 dark:border-slate-800 dark:bg-slate-900/60">
+              <div className="text-xs text-muted-foreground">{selectedDestPlaylist ? 1 : 0} selected</div>
+              <Button size="sm" onClick={() => { setConfirmedDestSelected(!!selectedDestPlaylist); setDestLibraryOpen(false) }}>Done</Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   )
 }

--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -392,6 +392,15 @@ export default function ActionPage() {
                     window.location.href = '/api/spotify/auth?ctx=destination'
                   }
                 }}>{destination === 'spotify' && spotifyDestUser ? `Signed in as ${spotifyDestUser.display_name || spotifyDestUser.id}` : 'Sign in'}</Button>
+                {mode === 'sync' && (
+                  <Button size="lg" variant="outline" className="w-full" disabled={!spotifyDestUser || !destination} onClick={() => setDestLibraryOpen(true)}>
+                    {confirmedDestSelected && selectedDestPlaylist ? (
+                      <span className="inline-flex items-center gap-2">
+                        <Check className="h-4 w-4" /> Selected 1 playlist
+                      </span>
+                    ) : 'Select content destination'}
+                  </Button>
+                )}
               </div>
             </>
           )}

--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -144,6 +144,10 @@ export default function ActionPage() {
     })
   }
 
+  const togglePickDest = (id: string) => {
+    setSelectedDestPlaylist((prev) => (prev === id ? null : id))
+  }
+
   const services: { id: ServiceId; name: string; enabled: boolean }[] = [
     { id: 'spotify', name: 'Spotify', enabled: true },
     { id: 'apple', name: 'Apple Music', enabled: false },


### PR DESCRIPTION
## Purpose

The user requested the ability to choose which playlist to sync content into during sync mode. They wanted a "Select content destination" button added below the sign-in button in step 2 of the sync process, allowing them to pick a specific destination playlist rather than having a fixed target.

## Code changes

- Added state management for destination playlist selection including loading states, error handling, and selected playlist tracking
- Implemented `useEffect` hook to fetch destination playlists from Spotify API when the destination library dialog opens
- Added "Select content destination" button that appears in sync mode after user authentication, showing selection status with a checkmark when a playlist is chosen
- Created a new modal dialog component for browsing and selecting destination playlists with radio button selection, playlist artwork, track counts, and a confirmation flow
- Added `togglePickDest` function to handle single playlist selection (radio button behavior) for the destination pickerTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 26`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0eddc91744f4938b31f03cd4f4d325c/stellar-home)

👀 [Preview Link](https://a0eddc91744f4938b31f03cd4f4d325c-stellar-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0eddc91744f4938b31f03cd4f4d325c</projectId>-->
<!--<branchName>stellar-home</branchName>-->