### PR TITLE
Allow liked songs playlist as sync destination

### DIFF
--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -594,13 +594,15 @@ export default function ActionPage() {
               {!loadingDestPlaylists && destPlaylistError && (
                 <div className="p-6 text-center text-sm text-red-600 dark:text-red-400">{destPlaylistError}</div>
               )}
-              {!loadingDestPlaylists && !destPlaylistError && destPlaylists.filter((pl) => pl.id !== 'liked_songs').length === 0 && (
+              {!loadingDestPlaylists && !destPlaylistError && destPlaylists.length === 0 && (
                 <div className="p-6 text-center text-sm text-muted-foreground">No playlists found</div>
               )}
               <ul className="space-y-1">
-                {destPlaylists.filter((pl) => pl.id !== 'liked_songs').map((pl) => {
+                {destPlaylists.map((pl) => {
                   const checked = selectedDestPlaylist === pl.id
-                  const artworkUrl = pl.image?.url || null
+                  const artworkUrl = pl.id === 'liked_songs'
+                    ? 'https://cdn.builder.io/api/v1/image/assets%2F672bd2452a84448ea16383bbff6a43d6%2F533ea5db8ac54bf58d52fcac265b743a?format=webp&width=800'
+                    : (pl.image?.url || null)
                   return (
                     <li key={pl.id}>
                       <button type="button" onClick={() => togglePickDest(pl.id)} className={[


### PR DESCRIPTION
## Purpose

The user requested the ability to select their "liked songs" auto playlist as a destination when using sync mode. This enhancement allows users to sync music directly to their liked songs collection, providing more flexibility in playlist management.

## Code changes

- Removed filter that excluded 'liked_songs' playlist from destination options
- Updated empty state check to show all playlists including liked songs
- Added custom artwork URL for liked songs playlist to provide visual consistency
- Modified playlist rendering to include liked songs in the selectable destination listTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0eddc91744f4938b31f03cd4f4d325c/vortex-realm)

👀 [Preview Link](https://a0eddc91744f4938b31f03cd4f4d325c-vortex-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0eddc91744f4938b31f03cd4f4d325c</projectId>-->
<!--<branchName>vortex-realm</branchName>-->