### PR TITLE
Add sync functionality with one-way/two-way modes

### DIFF
--- a/app/api/sync/start/route.ts
+++ b/app/api/sync/start/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { startSync } from '@/lib/transfer/serverJobs'
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => null)
+    if (!body || !body.source || !body.destination || (body.mode !== 'one_way' && body.mode !== 'two_way')) {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+    }
+    const source = body.source as { id: string; name: string }
+    const destination = body.destination as { id: string; name: string }
+    if (typeof source.id !== 'string' || typeof source.name !== 'string' || typeof destination.id !== 'string' || typeof destination.name !== 'string') {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+    }
+
+    const cookieStore = cookies()
+    const auth = {
+      sourceAccessToken: cookieStore.get('spotify_source_access_token')?.value || cookieStore.get('spotify_access_token')?.value || '',
+      sourceRefreshToken: cookieStore.get('spotify_source_refresh_token')?.value || cookieStore.get('spotify_refresh_token')?.value,
+      destAccessToken: cookieStore.get('spotify_destination_access_token')?.value || '',
+      destRefreshToken: cookieStore.get('spotify_destination_refresh_token')?.value,
+    }
+    if (!auth.sourceAccessToken || !auth.destAccessToken) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    }
+
+    const job = startSync({ source, destination, mode: body.mode, auth })
+    const res = NextResponse.json({ id: job.id, state: job })
+    res.cookies.set('active_transfer_job_id', job.id, { path: '/', httpOnly: false, maxAge: 60 * 60 })
+    return res
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'Server error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Purpose

The user requested implementation of server-side syncing functionality that works even when offline (once initiated), with configurable sync options (one-way or two-way) and a live sync progress card in the `/action` page.

## Code changes

### Frontend (`app/action/page.tsx`)
- Added `SyncMode` type and `syncMode` state for one-way/two-way selection
- Implemented sync mode toggle UI with ToggleGroup component
- Created `startSync()` function to initiate sync operations
- Updated progress card to show "Sync progress" vs "Transfer progress"
- Modified button handler to call appropriate function based on mode
- Updated dialog descriptions to reflect sync vs transfer context

### Backend (`app/api/sync/start/route.ts`)
- New API endpoint for starting sync operations
- Validates sync mode and playlist parameters
- Handles authentication via cookies
- Returns job ID and initial state

### Core Logic (`lib/transfer/serverJobs.ts`)
- Added `StartSyncInput` type and `SyncMode` definitions
- Implemented `runSpotifySync()` function for sync logic
- Added `extractTrackIdsFromUris()` helper for track ID extraction
- Created `addTracksToLikedSongsInBatches()` for liked songs support
- Implemented `startSync()` function to create and manage sync jobs
- Added support for both one-way and two-way synchronization with progress trackingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 29`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0eddc91744f4938b31f03cd4f4d325c/zen-studio)

👀 [Preview Link](https://a0eddc91744f4938b31f03cd4f4d325c-zen-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0eddc91744f4938b31f03cd4f4d325c</projectId>-->
<!--<branchName>zen-studio</branchName>-->