### PR TITLE
Add user-library-modify scope to Spotify auth

### DIFF
--- a/app/api/spotify/auth/route.ts
+++ b/app/api/spotify/auth/route.ts
@@ -25,6 +25,7 @@ export async function GET(request: Request) {
     'playlist-read-private',
     'playlist-read-collaborative',
     'user-library-read',
+    'user-library-modify',
     'playlist-modify-private',
     'playlist-modify-public',
     'ugc-image-upload',


### PR DESCRIPTION
## Purpose
Enable users to like songs directly through the application to sync them to their liked songs auto playlist. This addresses the requirement that users must like songs to have them automatically added to their liked songs playlist.

## Code changes
- Added `user-library-modify` scope to the Spotify OAuth authorization request
- This scope grants permission to modify the user's library (like/unlike songs)
- Positioned appropriately in the scopes array after `user-library-read`To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 30`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a0eddc91744f4938b31f03cd4f4d325c/zen-haven)

👀 [Preview Link](https://a0eddc91744f4938b31f03cd4f4d325c-zen-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0eddc91744f4938b31f03cd4f4d325c</projectId>-->
<!--<branchName>zen-haven</branchName>-->