### PR TITLE
Fix liked songs sync order by adding tracks individually

### DIFF
--- a/lib/transfer/serverJobs.ts
+++ b/lib/transfer/serverJobs.ts
@@ -165,16 +165,15 @@ function extractTrackIdsFromUris(uris: string[]): string[] {
     .filter((x): x is string => !!x)
 }
 
-async function addTracksToLikedSongsInBatches(token: string, ids: string[], onProgress: (added: number) => void) {
-  for (let i = 0; i < ids.length; i += 50) {
-    const batch = ids.slice(i, i + 50)
+async function addTracksToLikedSongsPreservingOrder(token: string, ids: string[], onProgress: (added: number) => void) {
+  for (let i = ids.length - 1; i >= 0; i--) {
     const res = await fetch('https://api.spotify.com/v1/me/tracks', {
       method: 'PUT',
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ids: batch })
+      body: JSON.stringify({ ids: [ids[i]] })
     })
     if (!res.ok) throw new Error('Failed to save tracks to library')
-    onProgress(batch.length)
+    onProgress(1)
   }
 }
 
@@ -251,7 +250,7 @@ async function runSpotifySync(job: TransferJobState, input: StartSyncInput) {
       log(job, `One-way sync: adding ${toDest.length} missing tracks to destination`)
       if (input.destination.id === 'liked_songs') {
         const ids = extractTrackIdsFromUris(toDest)
-        await addTracksToLikedSongsInBatches(destToken, ids, (added) => { item.added += added; item.message = `${item.added}/${item.total}` })
+        await addTracksToLikedSongsPreservingOrder(destToken, ids, (added) => { item.added += added; item.message = `${item.added}/${item.total}` })
       } else {
         await addTracksInBatches(destToken, input.destination.id, toDest, (added) => { item.added += added; item.message = `${item.added}/${item.total}` })
       }
@@ -264,7 +263,7 @@ async function runSpotifySync(job: TransferJobState, input: StartSyncInput) {
       log(job, `Two-way sync: adding ${toDest.length} tracks to destination`)
       if (input.destination.id === 'liked_songs') {
         const ids = extractTrackIdsFromUris(toDest)
-        await addTracksToLikedSongsInBatches(destToken, ids, (added) => { destItem.added += added; destItem.message = `${destItem.added}/${destItem.total}` })
+        await addTracksToLikedSongsPreservingOrder(destToken, ids, (added) => { destItem.added += added; destItem.message = `${destItem.added}/${destItem.total}` })
       } else {
         await addTracksInBatches(destToken, input.destination.id, toDest, (added) => { destItem.added += added; destItem.message = `${destItem.added}/${destItem.total}` })
       }
@@ -276,7 +275,7 @@ async function runSpotifySync(job: TransferJobState, input: StartSyncInput) {
       log(job, `Two-way sync: adding ${toSource.length} tracks to source`)
       if (input.source.id === 'liked_songs') {
         const ids = extractTrackIdsFromUris(toSource)
-        await addTracksToLikedSongsInBatches(sourceToken, ids, (added) => { sourceItem.added += added; sourceItem.message = `${sourceItem.added}/${sourceItem.total}` })
+        await addTracksToLikedSongsPreservingOrder(sourceToken, ids, (added) => { sourceItem.added += added; sourceItem.message = `${sourceItem.added}/${sourceItem.total}` })
       } else {
         await addTracksInBatches(sourceToken, input.source.id, toSource, (added) => { sourceItem.added += added; sourceItem.message = `${sourceItem.added}/${sourceItem.total}` })
       }


### PR DESCRIPTION
## Purpose

The user reported that when syncing to the liked auto playlist, songs were being added in batches which disrupted the original order. The order was also being reversed, and preserving the exact order from the source playlist is critical for the user's workflow.

## Code changes

- Renamed `addTracksToLikedSongsInBatches` to `addTracksToLikedSongsPreservingOrder` to better reflect its new behavior
- Changed from batch processing (50 tracks at a time) to individual track processing (1 track at a time)
- Modified the loop to iterate backwards through the track list (`i = ids.length - 1; i >= 0; i--`) to preserve the original order
- Updated all three call sites in the sync function to use the new order-preserving method
- Adjusted progress reporting to increment by 1 instead of batch sizeTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 31`

🔗 [Edit in Builder.io](https://builder.io/app/projects/df0d7066b8064821bc66d7eb4a030f1d/echo-zone)

👀 [Preview Link](https://df0d7066b8064821bc66d7eb4a030f1d-echo-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>df0d7066b8064821bc66d7eb4a030f1d</projectId>-->
<!--<branchName>echo-zone</branchName>-->