### PR TITLE
Reverse track order when syncing to liked songs playlist

### DIFF
--- a/lib/transfer/serverJobs.ts
+++ b/lib/transfer/serverJobs.ts
@@ -314,7 +314,7 @@ async function runSpotifySync(job: TransferJobState, input: StartSyncInput) {
       item.total = toDest.length
       log(job, `One-way sync: adding ${toDest.length} missing tracks to destination`)
       if (input.destination.id === 'liked_songs') {
-        const ids = extractTrackIdsFromUris(toDest)
+        const ids = extractTrackIdsFromUris(toDest).slice().reverse()
         await addTracksToLikedSongsSequential(destToken, ids, (added) => { item.added += added; item.message = `${item.added}/${item.total}` })
       } else {
         await addTracksInBatches(destToken, input.destination.id, toDest, (added) => { item.added += added; item.message = `${item.added}/${item.total}` })
@@ -342,7 +342,7 @@ async function runSpotifySync(job: TransferJobState, input: StartSyncInput) {
       destItem.total = toDest.length
       log(job, `Two-way sync: adding ${toDest.length} tracks to destination`)
       if (input.destination.id === 'liked_songs') {
-        const ids = extractTrackIdsFromUris(toDest)
+        const ids = extractTrackIdsFromUris(toDest).slice().reverse()
         await addTracksToLikedSongsSequential(destToken, ids, (added) => { destItem.added += added; destItem.message = `${destItem.added}/${destItem.total}` })
       } else {
         await addTracksInBatches(destToken, input.destination.id, toDest, (added) => { destItem.added += added; destItem.message = `${destItem.added}/${destItem.total}` })
@@ -354,7 +354,7 @@ async function runSpotifySync(job: TransferJobState, input: StartSyncInput) {
       sourceItem.total = toSource.length
       log(job, `Two-way sync: adding ${toSource.length} tracks to source`)
       if (input.source.id === 'liked_songs') {
-        const ids = extractTrackIdsFromUris(toSource)
+        const ids = extractTrackIdsFromUris(toSource).slice().reverse()
         await addTracksToLikedSongsSequential(sourceToken, ids, (added) => { sourceItem.added += added; sourceItem.message = `${sourceItem.added}/${sourceItem.total}` })
       } else {
         await addTracksInBatches(sourceToken, input.source.id, toSource, (added) => { sourceItem.added += added; sourceItem.message = `${sourceItem.added}/${sourceItem.total}` })


### PR DESCRIPTION
## Purpose

Fix the track order when syncing to the liked songs auto playlist to match the source playlist order. The user reported that tracks were being added in the wrong order, making the synced playlist not match the original source order.

## Code changes

Modified the Spotify sync logic in `serverJobs.ts` to reverse the track order before adding tracks to liked songs playlists:

- Added `.slice().reverse()` to track ID arrays in three sync scenarios:
  - One-way sync to liked songs destination
  - Two-way sync to liked songs destination  
  - Two-way sync to liked songs source

This ensures tracks are added in reverse order to the liked songs playlist, which results in the correct final order matching the source playlist.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 36`

🔗 [Edit in Builder.io](https://builder.io/app/projects/df0d7066b8064821bc66d7eb4a030f1d/stellar-world)

👀 [Preview Link](https://df0d7066b8064821bc66d7eb4a030f1d-stellar-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>df0d7066b8064821bc66d7eb4a030f1d</projectId>-->
<!--<branchName>stellar-world</branchName>-->