### PR TITLE
Move transfer and sync operations to client-side

### DIFF
--- a/app/api/spotify/callback/route.ts
+++ b/app/api/spotify/callback/route.ts
@@ -45,11 +45,11 @@ export async function GET(request: Request) {
 
     const res = NextResponse.redirect(new URL(`/action?auth=spotify&ctx=${ctx}`, url))
     const expiresAt = Date.now() + token.expires_in * 1000 - 30 * 1000
-    res.cookies.set(`spotify_${ctx}_access_token`, token.access_token, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: token.expires_in })
+    res.cookies.set(`spotify_${ctx}_access_token`, token.access_token, { httpOnly: false, secure: true, sameSite: 'lax', path: '/', maxAge: token.expires_in })
     if (token.refresh_token) {
-      res.cookies.set(`spotify_${ctx}_refresh_token`, token.refresh_token, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 60 * 60 * 24 * 30 })
+      res.cookies.set(`spotify_${ctx}_refresh_token`, token.refresh_token, { httpOnly: false, secure: true, sameSite: 'lax', path: '/', maxAge: 60 * 60 * 24 * 30 })
     }
-    res.cookies.set(`spotify_${ctx}_expires_at`, String(expiresAt), { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: token.expires_in })
+    res.cookies.set(`spotify_${ctx}_expires_at`, String(expiresAt), { httpOnly: false, secure: true, sameSite: 'lax', path: '/', maxAge: token.expires_in })
     res.cookies.set(`spotify_${ctx}_pkce_verifier`, '', { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 0 })
     res.cookies.set(`spotify_${ctx}_oauth_state`, '', { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 0 })
     // Clear legacy cookies if present

--- a/app/api/spotify/me/route.ts
+++ b/app/api/spotify/me/route.ts
@@ -58,11 +58,11 @@ export async function GET(request: Request) {
   const res = NextResponse.json(out)
   if (updated) {
     const maxAge = Math.max(0, Math.floor((newExpiresAt - Date.now()) / 1000))
-    res.cookies.set(`spotify_${ctx}_access_token`, accessToken, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
+    res.cookies.set(`spotify_${ctx}_access_token`, accessToken, { httpOnly: false, secure: true, sameSite: 'lax', path: '/', maxAge })
     if (newRefreshToken) {
-      res.cookies.set(`spotify_${ctx}_refresh_token`, newRefreshToken, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 60 * 60 * 24 * 30 })
+      res.cookies.set(`spotify_${ctx}_refresh_token`, newRefreshToken, { httpOnly: false, secure: true, sameSite: 'lax', path: '/', maxAge: 60 * 60 * 24 * 30 })
     }
-    res.cookies.set(`spotify_${ctx}_expires_at`, String(newExpiresAt), { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
+    res.cookies.set(`spotify_${ctx}_expires_at`, String(newExpiresAt), { httpOnly: false, secure: true, sameSite: 'lax', path: '/', maxAge })
   }
   return res
 }

--- a/app/api/spotify/playlists/route.ts
+++ b/app/api/spotify/playlists/route.ts
@@ -78,11 +78,11 @@ export async function GET(request: Request) {
   const res = NextResponse.json({ items: playlists })
   if (updated) {
     const maxAge = Math.max(0, Math.floor((newExpiresAt - Date.now()) / 1000))
-    res.cookies.set(`spotify_${ctx}_access_token`, accessToken, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
+    res.cookies.set(`spotify_${ctx}_access_token`, accessToken, { httpOnly: false, secure: true, sameSite: 'lax', path: '/', maxAge })
     if (newRefreshToken) {
-      res.cookies.set(`spotify_${ctx}_refresh_token`, newRefreshToken, { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 60 * 60 * 24 * 30 })
+      res.cookies.set(`spotify_${ctx}_refresh_token`, newRefreshToken, { httpOnly: false, secure: true, sameSite: 'lax', path: '/', maxAge: 60 * 60 * 24 * 30 })
     }
-    res.cookies.set(`spotify_${ctx}_expires_at`, String(newExpiresAt), { httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge })
+    res.cookies.set(`spotify_${ctx}_expires_at`, String(newExpiresAt), { httpOnly: false, secure: true, sameSite: 'lax', path: '/', maxAge })
   }
   return res
 }


### PR DESCRIPTION
## Purpose

The user requested to make transfer and sync operations client-side once more, moving away from server-side processing to handle playlist operations directly in the browser.

## Code changes

- **Client-side transfer logic**: Added comprehensive client-side functions for playlist operations including track fetching, playlist creation, and batch operations
- **Direct Spotify API calls**: Implemented functions to interact directly with Spotify API from the browser for transfers and syncs
- **Cookie access**: Made authentication cookies accessible to client-side JavaScript by changing `httpOnly: false` across all Spotify token cookies
- **Helper functions**: Added utilities for cookie reading, token management, logging, and progress tracking
- **Removed server dependency**: Replaced server-based job management with local state management for transfer operations
- **Enhanced sync logic**: Implemented both one-way and two-way sync operations with proper progress tracking and error handlingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 37`

🔗 [Edit in Builder.io](https://builder.io/app/projects/df0d7066b8064821bc66d7eb4a030f1d/vortex-hub)

👀 [Preview Link](https://df0d7066b8064821bc66d7eb4a030f1d-vortex-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>df0d7066b8064821bc66d7eb4a030f1d</projectId>-->
<!--<branchName>vortex-hub</branchName>-->