### PR TITLE
Add optional toggle for removing tracks in one-way sync

### DIFF
--- a/app/action/page.tsx
+++ b/app/action/page.tsx
@@ -2,6 +2,7 @@
 
 import * as ToggleGroup from '@radix-ui/react-toggle-group'
 import * as Dialog from '@radix-ui/react-dialog'
+import * as Switch from '@radix-ui/react-switch'
 import { Button } from '@/components/ui/button'
 import { Check, ChevronRight, ChevronLeft } from 'lucide-react'
 import { useState, useEffect, useLayoutEffect } from 'react'
@@ -24,6 +25,7 @@ type SyncMode = 'one_way' | 'two_way'
 export default function ActionPage() {
   const [mode, setMode] = useState<'transfer' | 'sync'>('transfer')
   const [syncMode, setSyncMode] = useState<SyncMode>('one_way')
+  const [removeMissing, setRemoveMissing] = useState(false)
   const [source, setSource] = useState<ServiceId | null>(null)
   const [destination, setDestination] = useState<ServiceId | null>(null)
 
@@ -477,7 +479,7 @@ export default function ActionPage() {
         }
 
         const toRemoveFromDest = destUris.filter((u) => !sourceSet.has(u))
-        if (toRemoveFromDest.length > 0) {
+        if (removeMissing && toRemoveFromDest.length > 0) {
           logAppend(setJob, `One-way sync: removing ${toRemoveFromDest.length} tracks from destination not present in source`)
           if (dst.id === 'liked_songs') {
             const rmIds = extractTrackIdsFromUris(toRemoveFromDest)
@@ -487,7 +489,7 @@ export default function ActionPage() {
           }
           logAppend(setJob, `Removed ${toRemoveFromDest.length} tracks from destination`)
         } else {
-          logAppend(setJob, 'No tracks to remove from destination')
+          logAppend(setJob, removeMissing ? 'No tracks to remove from destination' : 'Removal disabled: skipping removal from destination')
         }
 
         updateItem(setJob, itemId, { status: 'completed' })
@@ -725,6 +727,20 @@ export default function ActionPage() {
                       <ToggleGroup.Item value="one_way" className="rounded-full px-5 py-2 text-sm font-medium text-slate-700 transition-colors data-[state=on]:bg-[#7c3aed] data-[state=on]:text-white dark:text-slate-200">One way</ToggleGroup.Item>
                       <ToggleGroup.Item value="two_way" className="rounded-full px-5 py-2 text-sm font-medium text-slate-700 transition-colors data-[state=on]:bg-[#7c3aed] data-[state=on]:text-white dark:text-slate-200">Two way</ToggleGroup.Item>
                     </ToggleGroup.Root>
+                  </div>
+                )}
+                {mode === 'sync' && syncMode === 'one_way' && (
+                  <div className="mt-4 flex items-center justify-center">
+                    <label className="flex items-center gap-3 text-sm text-slate-700 dark:text-slate-200">
+                      <Switch.Root
+                        checked={removeMissing}
+                        onCheckedChange={setRemoveMissing}
+                        className="relative inline-flex h-6 w-11 items-center rounded-full border bg-white/70 transition-colors data-[state=checked]:bg-[#7c3aed] dark:border-slate-800 dark:bg-slate-900/40"
+                      >
+                        <Switch.Thumb className="block h-5 w-5 translate-x-1 rounded-full bg-white shadow transition-transform data-[state=checked]:translate-x-5 dark:bg-slate-200" />
+                      </Switch.Root>
+                      <span>Remove tracks in destination not in source</span>
+                    </label>
                   </div>
                 )}
                 <div className="mt-5 grid gap-4">

--- a/app/api/sync/start/route.ts
+++ b/app/api/sync/start/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
     }
 
-    const job = startSync({ source, destination, mode: body.mode, auth })
+    const job = startSync({ source, destination, mode: body.mode, removeMissing: !!body.removeMissing, auth })
     const res = NextResponse.json({ id: job.id, state: job })
     res.cookies.set('active_transfer_job_id', job.id, { path: '/', httpOnly: false, maxAge: 60 * 60 })
     return res

--- a/lib/transfer/serverJobs.ts
+++ b/lib/transfer/serverJobs.ts
@@ -38,6 +38,7 @@ export type StartSyncInput = {
   source: { id: string; name: string }
   destination: { id: string; name: string }
   mode: SyncMode
+  removeMissing?: boolean
   auth: {
     sourceAccessToken: string
     sourceRefreshToken?: string
@@ -321,7 +322,7 @@ async function runSpotifySync(job: TransferJobState, input: StartSyncInput) {
       }
 
       const toRemoveFromDest = destUris.filter((u) => !sourceSet.has(u))
-      if (toRemoveFromDest.length > 0) {
+      if (input.removeMissing && toRemoveFromDest.length > 0) {
         log(job, `One-way sync: removing ${toRemoveFromDest.length} tracks from destination not present in source`)
         if (input.destination.id === 'liked_songs') {
           const rmIds = extractTrackIdsFromUris(toRemoveFromDest)
@@ -331,7 +332,7 @@ async function runSpotifySync(job: TransferJobState, input: StartSyncInput) {
         }
         log(job, `Removed ${toRemoveFromDest.length} tracks from destination`)
       } else {
-        log(job, 'No tracks to remove from destination')
+        log(job, input.removeMissing ? 'No tracks to remove from destination' : 'Removal disabled: skipping removal from destination')
       }
 
       item.status = 'completed'


### PR DESCRIPTION
## Purpose

Based on user feedback, this change makes track removal in one-way sync mode optional rather than automatic. Users requested the ability to control whether tracks present in the destination but not in the source should be removed, with removal disabled by default for safer operation.

## Code changes

- Added a new toggle switch in the UI for one-way sync mode to control track removal behavior
- Introduced `removeMissing` state variable (defaults to `false`) 
- Updated sync logic to only remove tracks when the toggle is enabled
- Modified API endpoint to accept the `removeMissing` parameter
- Updated log messages to indicate when removal is disabled vs when there are no tracks to remove
- Added Radix UI Switch component for the toggle interfaceTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 38`

🔗 [Edit in Builder.io](https://builder.io/app/projects/df0d7066b8064821bc66d7eb4a030f1d/vortex-works)

👀 [Preview Link](https://df0d7066b8064821bc66d7eb4a030f1d-vortex-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>df0d7066b8064821bc66d7eb4a030f1d</projectId>-->
<!--<branchName>vortex-works</branchName>-->