### PR TITLE
Add favicon and update site metadata for MusicNomad

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,8 +7,8 @@ import Navbar from '@/components/site/Navbar'
 import { ThemeProvider } from '@/components/theme-provider'
 
 export const metadata: Metadata = {
-  title: 'v0 App',
-  description: 'Created with v0',
+  title: 'MusicNomad',
+  description: 'Move and Synchronise your playlists for free',
   generator: 'v0.app',
 }
 


### PR DESCRIPTION
## Purpose
The user requested to enhance the site's branding by using the existing logo as the favicon, updating the website title to "MusicNomad", and setting the description to "Move and Synchronise your playlists for free" to better reflect the site's purpose.

## Code changes
- **Added favicon**: Created `app/icon.svg` with a music note icon (purple stroke, 32x32 viewBox)
- **Updated metadata**: Changed site title from "v0 App" to "MusicNomad" 
- **Updated description**: Changed from "Created with v0" to "Move and Synchronise your playlists for free"To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 40`

🔗 [Edit in Builder.io](https://builder.io/app/projects/df0d7066b8064821bc66d7eb4a030f1d/zen-world)

👀 [Preview Link](https://df0d7066b8064821bc66d7eb4a030f1d-zen-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>df0d7066b8064821bc66d7eb4a030f1d</projectId>-->
<!--<branchName>zen-world</branchName>-->